### PR TITLE
Fix JWT decoding for user role

### DIFF
--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import { decodeJwtPayload } from '@/lib/utils'
 
 export async function login(formData: FormData) {
   const supabase = await createClient()
@@ -94,8 +95,7 @@ export async function getUserRole() {
 
   // Get the JWT and decode it
   const token = session.access_token
-  const payload = token.split('.')[1]
-  const decoded = JSON.parse(atob(payload))
+  const decoded = decodeJwtPayload(token)
 
   return decoded.user_role || 'user'
 }

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -2,6 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { createClient } from "@/lib/supabase/client";
+import { decodeJwtPayload } from "@/lib/utils";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -100,9 +101,8 @@ export function useUserRole() {
       if (!sessionData.session) return null;
       
       const token = sessionData.session.access_token;
-      const payload = token.split('.')[1];
-      const decoded = JSON.parse(atob(payload));
-      
+      const decoded = decodeJwtPayload(token);
+
       return decoded.user_role || 'user';
     },
     enabled: !!user,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,23 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Decode a JWT payload using base64url decoding
+export function decodeJwtPayload(token: string): Record<string, any> {
+  const payload = token.split('.')[1]
+  if (!payload) return {}
+
+  // Convert from base64url to base64
+  let base64 = payload.replace(/-/g, '+').replace(/_/g, '/')
+  const padding = base64.length % 4
+  if (padding) {
+    base64 += '='.repeat(4 - padding)
+  }
+
+  try {
+    const decoded = atob(base64)
+    return JSON.parse(decoded)
+  } catch {
+    return {}
+  }
+}


### PR DESCRIPTION
## Summary
- handle base64url tokens when decoding JWTs
- update user role helpers to use the new decoder

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb5bfc598832d9d2ac9acb7b9e262