### PR TITLE
Improve Supabase client usage

### DIFF
--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -6,7 +6,7 @@ import { createClient } from '@/lib/supabase/server'
 import type { AppRole, AppPermission, ProviderRoleType } from '@/types'
 
 export async function login(formData: FormData) {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   const data = {
     email: formData.get('email') as string,
@@ -24,7 +24,7 @@ export async function login(formData: FormData) {
 }
 
 export async function signInWithGoogle() {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
@@ -42,7 +42,7 @@ export async function signInWithGoogle() {
 }
 
 export async function signInWithFacebook() {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'facebook',
@@ -59,7 +59,7 @@ export async function signInWithFacebook() {
 }
 
 export async function signup(formData: FormData) {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   const data = {
     email: formData.get('email') as string,
@@ -81,14 +81,14 @@ export async function signup(formData: FormData) {
 }
 
 export async function signout() {
-  const supabase = await createClient()
+  const supabase = createClient()
   await supabase.auth.signOut()
   revalidatePath('/', 'layout')
   redirect('/login')
 }
 
 async function getUserPermissionsForRole(role: AppRole, provider_role?: ProviderRoleType | null): Promise<AppPermission[]> {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   // For catering_provider role, get provider sub-role permissions
   if (role === 'catering_provider' && provider_role) {
@@ -116,7 +116,7 @@ export async function getUserRole(): Promise<{
   provider_role: ProviderRoleType | null;
   permissions: AppPermission[];
 } | null> {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   try {
     const { data: { session }, error } = await supabase.auth.getSession()
@@ -158,7 +158,7 @@ export async function getUserPermissions(): Promise<AppPermission[]> {
 }
 
 export async function refreshSession() {
-  const supabase = await createClient()
+  const supabase = createClient()
 
   try {
     const { data, error } = await supabase.auth.refreshSession()

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
 
     // Exchange code for session
     if (code) {
-      const supabase = await createClient()
+      const supabase = createClient()
       const { data, error } = await supabase.auth.exchangeCodeForSession(code)
 
       if (error) {

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
   const next = searchParams.get('next') ?? '/dashboard'
 
   if (token_hash && type) {
-    const supabase = await createClient()
+    const supabase = createClient()
 
     const { error } = await supabase.auth.verifyOtp({
       type,

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -10,7 +10,7 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = await createClient();
+  const supabase = createClient();
 
   // Check if user is logged in
   const {
@@ -22,7 +22,7 @@ export default async function DashboardLayout({
   }
 
   // Get sidebar state from cookie
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
   const defaultOpen = cookieStore.get("sidebar_state")?.value === "true";
 
   return (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,7 +5,7 @@ import { Typography } from "@/components/ui/typography";
 import { UserRoleData } from "@/types";
 
 export default async function DashboardPage() {
-  const supabase = await createClient();
+  const supabase = createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/app/dashboard/settings/actions.ts
+++ b/app/dashboard/settings/actions.ts
@@ -12,7 +12,7 @@ interface ProfileUpdateData {
 }
 
 export async function updateProfile(data: ProfileUpdateData) {
-  const supabase = await createClient()
+  const supabase = createClient()
   
   if (!data.id) {
     throw new Error('User ID is required')

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,8 +1,15 @@
 import { createBrowserClient } from '@supabase/ssr'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+let browserClient: SupabaseClient | null = null
 
 export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  )
+  if (!browserClient) {
+    browserClient = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
+  }
+
+  return browserClient
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,29 +1,25 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import { cache } from 'react'
 
-export async function createClient() {
-  const cookieStore = await cookies()
+export const createClient = cache(() => {
+  const cookieStore = cookies()
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        getAll() {
-          return cookieStore.getAll()
+        get(name: string) {
+          return cookieStore.get(name)?.value
         },
-        setAll(cookiesToSet) {
-          try {
-            cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
-            )
-          } catch {
-            // The `setAll` method was called from a Server Component.
-            // This can be ignored if you have middleware refreshing
-            // user sessions.
-          }
+        set(name: string, value: string, options: Parameters<typeof cookieStore.set>[2]) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name: string, options: Parameters<typeof cookieStore.delete>[1]) {
+          cookieStore.delete(name, options)
         },
       },
     }
   )
-}
+})


### PR DESCRIPTION
## Summary
- cache Supabase browser client
- use React cache for server client and remove async usage
- update calls to use new cached client

## Testing
- `npm run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840790fe9dc832d9bb8751ec5d5e15b