### PR TITLE
Fix TS errors in hooks

### DIFF
--- a/hooks/use-onboarding-form.ts
+++ b/hooks/use-onboarding-form.ts
@@ -118,7 +118,7 @@ export function useOnboardingForm(options: UseOnboardingFormOptions = {}): Onboa
 
   // Initialize form with combined schema
   const form = useForm<ProviderOnboardingData>({
-    resolver: zodResolver<ProviderOnboardingData>(providerOnboardingSchema),
+    resolver: zodResolver(providerOnboardingSchema),
     defaultValues: defaultValues as ProviderOnboardingData,
     mode: "onChange",
   });
@@ -235,7 +235,7 @@ export function useOnboardingForm(options: UseOnboardingFormOptions = {}): Onboa
     const stepData: Partial<ProviderOnboardingData> = {};
 
     stepFields.forEach(field => {
-      stepData[field] = values[field];
+      stepData[field] = values[field] as any;
     });
     
     return stepData;
@@ -313,14 +313,14 @@ export function useOnboardingForm(options: UseOnboardingFormOptions = {}): Onboa
       const defaultStepData: Partial<ProviderOnboardingData> = {};
 
     stepFields.forEach(field => {
-        defaultStepData[field] = DEFAULT_VALUES[field];
+        defaultStepData[field] = DEFAULT_VALUES[field] as any;
       });
 
       // Reset only the fields for this step
       stepFields.forEach(field => {
         setValue(
           field,
-          defaultStepData[field] as ProviderOnboardingData[keyof ProviderOnboardingData],
+          defaultStepData[field] as any,
           {
             shouldValidate: true,
             shouldDirty: true,

--- a/hooks/use-supabase-query.ts
+++ b/hooks/use-supabase-query.ts
@@ -313,13 +313,13 @@ export function useRealtimeSubscription<T>(
         const channel = supabase
           .channel(`${table}_changes`)
           .on(
-            'postgres_changes',
+            'postgres_changes' as any,
             {
               event: options?.event || '*',
               schema: 'public',
               table: table,
               filter: options?.filter
-            },
+            } as any,
             (payload: any) => {
               if (IS_DEV) {
                 console.log(`Real-time change in ${table}:`, payload);


### PR DESCRIPTION
## Summary
- update `useOnboardingForm` resolver and add casts
- allow generic realtime subscription call for postgres changes

## Testing
- `pnpm lint`
- `npx tsc --noEmit` *(fails: Property `_def` does not exist on type `{}` and other component type errors)*


------
https://chatgpt.com/codex/tasks/task_e_687b36cfa5dc832d891d01c3311973a3