### PR TITLE
Add Next.js env type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited directly.
+// See https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## Summary
- allow tracking of Next.js generated TypeScript environment definitions
- add standard next-env.d.ts to restore Next-specific type declarations

## Testing
- not run (Node.js tooling unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69344b7a4ed8832da6f7f90a53935968)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to track Next.js environment type definitions, ensuring all developers have consistent TypeScript type declarations throughout the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->